### PR TITLE
allow to customize internal object creator to allow keeping native order during decode

### DIFF
--- a/src/lunajson/decoder.lua
+++ b/src/lunajson/decoder.lua
@@ -15,7 +15,7 @@ end
 local _ENV = nil
 
 local function newdecoder()
-	local json, pos, nullv, arraylen
+	local json, pos, nullv, arraylen, newobj
 
 	-- `f` is the temporary for dispatcher[c] and
 	-- the dummy for the first return value of `find`
@@ -228,7 +228,7 @@ local function newdecoder()
 	--]]
 	-- array
 	local function f_ary()
-		local ary = {}
+		local ary = {} -- no issue with lua numerical index
 
 		f, pos = find(json, '^[ \n\r\t]*', pos)
 		pos = pos+1
@@ -260,7 +260,7 @@ local function newdecoder()
 
 	-- objects
 	local function f_obj()
-		local obj = {}
+		local obj = newobj and newobj() or {}
 
 		f, pos = find(json, '^[ \n\r\t]*', pos)
 		pos = pos+1
@@ -336,8 +336,8 @@ local function newdecoder()
 	--[[
 		run decoder
 	--]]
-	local function decode(json_, pos_, nullv_, arraylen_)
-		json, pos, nullv, arraylen = json_, pos_, nullv_, arraylen_
+	local function decode(json_, pos_, nullv_, arraylen_, newobj_)
+		json, pos, nullv, arraylen, newobj = json_, pos_, nullv_, arraylen_, newobj_
 
 		pos = pos or 1
 		f, pos = find(json, '^[ \n\r\t]*', pos)


### PR DESCRIPTION
Hello,

A lua simple hash table does not remind the original order.
The only way to remind the write order is to setup a special metatable.
I didn't try to implement this feature inside lunajson but allow to customized it with an external handler.

My [test sample](https://github.com/tst2005/lunajson/blob/keep-order-sample/src/test.lunajson-order.lua) has a stable result :
```
DEBUG: writeorder.newtable: rawset      a       aa
DEBUG: writeorder.newtable: rawset      c       cc
DEBUG: writeorder.newtable: rawset      b       bb
a       aa
c       cc
b       bb
1       11
2       22
3       33
```


Regards,