### PR TITLE
support partial data decoding

### DIFF
--- a/src/lunajson/decoder.lua
+++ b/src/lunajson/decoder.lua
@@ -506,7 +506,10 @@ local function newdecoder()
 		else
 			f, pos = find(json, '^[ \n\r\t]*', pos)
 			if pos ~= #json then
-				decode_error('json ended')
+				if pos_ == nil then
+					decode_error('json ended')
+				end
+				return v, pos
 			end
 			return v
 		end


### PR DESCRIPTION
`decode(data)` will raise an error if there is extra data after the end of the json.
`decode(data, 1)` will return the parsed json data and the position of the reminding data to be able to parse the next part of the data