### PR TITLE
Use `n` for total number of parameters

### DIFF
--- a/src/lunajson/encoder.lua
+++ b/src/lunajson/encoder.lua
@@ -17,7 +17,7 @@ end
 local _ENV = nil
 
 
-local function newencoder()
+local function newencoder(saxtbl)
 	local v, nullv
 	local i, builder, visited
 
@@ -93,7 +93,7 @@ local function newencoder()
 		end
 		visited[o] = true
 
-		local tmp = o[0]
+		local tmp = o.n
 		if type(tmp) == 'number' then -- arraylen available
 			builder[i] = '['
 			i = i+1


### PR DESCRIPTION
Since lua 5.2, lua has had an 'official' way of representing a list's length - [table.pack](https://www.lua.org/manual/5.2/manual.html#pdf-table.pack) returns a table with a `n` field containing the total number of parameters