### PR TITLE
Expose encoder dispatcher for modification

### DIFF
--- a/src/lunajson/encoder.lua
+++ b/src/lunajson/encoder.lua
@@ -179,7 +179,7 @@ local function newencoder()
 		return concat(builder)
 	end
 
-	return encode
+	return encode, dispatcher
 end
 
 return newencoder


### PR DESCRIPTION
Expose the dispatcher table to allow custom encoding of data types.

Example use case:

```lua
local zero_based_meta = {
  __index = function(t, k)
    return t.raw[k + 1]
  end
}
local encode, dispatcher = newencoder()

local f_table = dispatcher.table
function dispatcher.table(o)
  return f_table(getmetatable(o) == zero_based_meta and o.raw or o)
end
```